### PR TITLE
Bugfix/only sent reply for non empty values

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = olink-core
-version = 0.3.1
+version = 0.3.2
 author = ApiGear
 author_email = info@apigear.io
 description = ObjectLink Core Protocol

--- a/src/olink/remote/node.py
+++ b/src/olink/remote/node.py
@@ -43,7 +43,9 @@ class RemoteNode(BaseNode):
         source = self.get_source(name)
         if source:
             value = source.olink_invoke(name, args)
-            self.emit_write(Protocol.invoke_reply_message(id, name, value))
+            # only send reply for not empty values
+            if value:
+                self.emit_write(Protocol.invoke_reply_message(id, name, value))
 
     def registry(self) -> RemoteRegistry:
         # returns global registry


### PR DESCRIPTION
## 📑 Description
The python protocol implementation always send a return message on invoke regardless of whether the value actually was empty.
Following the other implementations we only send invoke_reply for non-empty values.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed