### PR TITLE
chore: declare MIT in pyproject.toml and update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2020-2021 ApiGear UG (haftungsbeschränkt)
-Copyright (c) 2021-2023 Epic Games Inc. All rights reserved.
+Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+Copyright (c) 2022-2026 Epic Games, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,22 @@
+[project]
+name = "olink-core"
+version = "0.4.0"
+description = "ObjectLink core protocol for Python"
+readme = "README.md"
+requires-python = ">=3.9"
+license = "MIT"
+authors = [
+    {name = "ApiGear UG"},
+    {name = "Epic Games, Inc."},
+]
+
+[project.urls]
+Homepage = "https://github.com/apigear-io/objectlink-core-python"
+"Bug Tracker" = "https://github.com/apigear-io/objectlink-core-python/issues"
+
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=61.0",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,24 +1,15 @@
+# Project metadata (name, version, description, license, authors, URLs) is
+# declared in pyproject.toml under [project]. This file keeps only the
+# setuptools-specific package discovery and optional-dependency configuration.
+
 [metadata]
-name = olink-core
-version = 0.4.0
 author = ApiGear
 author_email = info@apigear.io
-description = ObjectLink Core Protocol
-long_description = file: README.md
-long_description_content_type = text/markdown
-url = https://github.com/apigear-io/objectlink-core-python
-project_urls =
-    Bug Tracker = https://github.com/apigear-io/objectlink-core-python/issues
-classifiers =
-    Programming Language :: Python :: 3
-    License :: OSI Approved :: MIT License
-    Operating System :: OS Independent
 
 [options]
 package_dir =
     = src
 packages = find:
-python_requires = >=3.9
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Adds a PEP 621 [project] table to pyproject.toml so pip, PyPI, and SBOM scanners detect the MIT license, and updates the LICENSE copyright lines for consistency.